### PR TITLE
Changed enchanting table to check for the `c:bookshelves` tag

### DIFF
--- a/src/main/java/io/github/frqnny/darkenchanting/util/BookcaseUtils.java
+++ b/src/main/java/io/github/frqnny/darkenchanting/util/BookcaseUtils.java
@@ -1,39 +1,44 @@
 package io.github.frqnny.darkenchanting.util;
 
-import net.minecraft.block.Blocks;
+import net.minecraft.block.Block;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 
 public class BookcaseUtils {
     public static int getBookshelfCount(World world, BlockPos blockPos) {
         int bookshelves = 0;
 
+        Tag<Block> bookshelvesTag = world.getTagManager().getTag(Registry.BLOCK_KEY, new Identifier("c", "bookshelves"), id -> new RuntimeException("Could not load tag: " + id.toString()));
+
         int j;
         for (j = -1; j <= 1; ++j) {
             for (int k = -1; k <= 1; ++k) {
                 if ((j != 0 || k != 0) && world.isAir(blockPos.add(k, 0, j)) && world.isAir(blockPos.add(k, 1, j))) {
-                    if (world.getBlockState(blockPos.add(k * 2, 0, j * 2)).isOf(Blocks.BOOKSHELF)) {
+                    if (world.getBlockState(blockPos.add(k * 2, 0, j * 2)).isIn(bookshelvesTag)) {
                         ++bookshelves;
                     }
 
-                    if (world.getBlockState(blockPos.add(k * 2, 1, j * 2)).isOf(Blocks.BOOKSHELF)) {
+                    if (world.getBlockState(blockPos.add(k * 2, 1, j * 2)).isIn(bookshelvesTag)) {
                         ++bookshelves;
                     }
 
                     if (k != 0 && j != 0) {
-                        if (world.getBlockState(blockPos.add(k * 2, 0, j)).isOf(Blocks.BOOKSHELF)) {
+                        if (world.getBlockState(blockPos.add(k * 2, 0, j)).isIn(bookshelvesTag)) {
                             ++bookshelves;
                         }
 
-                        if (world.getBlockState(blockPos.add(k * 2, 1, j)).isOf(Blocks.BOOKSHELF)) {
+                        if (world.getBlockState(blockPos.add(k * 2, 1, j)).isIn(bookshelvesTag)) {
                             ++bookshelves;
                         }
 
-                        if (world.getBlockState(blockPos.add(k, 0, j * 2)).isOf(Blocks.BOOKSHELF)) {
+                        if (world.getBlockState(blockPos.add(k, 0, j * 2)).isIn(bookshelvesTag)) {
                             ++bookshelves;
                         }
 
-                        if (world.getBlockState(blockPos.add(k, 1, j * 2)).isOf(Blocks.BOOKSHELF)) {
+                        if (world.getBlockState(blockPos.add(k, 1, j * 2)).isIn(bookshelvesTag)) {
                             ++bookshelves;
                         }
                     }

--- a/src/main/resources/data/c/tags/blocks/bookshelves.json
+++ b/src/main/resources/data/c/tags/blocks/bookshelves.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bookshelf"
+  ]
+}


### PR DESCRIPTION
Small change to search for blocks with the `c:bookshelves` tag (used by Charm, ATBYW, and more) instead of being hard-coded to the vanilla bookshelf.

Also adds the `c:bookshelves` tag to the vanilla bookshelf.