### PR TITLE
Add compat with BetterNether blue crying obsidian and enable Mod Menu gui

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	modImplementation include("io.github.cottonmc:LibGui:${project.libgui_version}")
 
 	modImplementation include("com.github.Draylar.omega-config:omega-config-base:${project.config_version}")
+	modImplementation include("com.github.Draylar.omega-config:omega-config-gui:${project.config_version}")
+	modRuntimeOnly("com.terraformersmc:modmenu:${project.mod_menu_version}")
 
 }
 repositories {
@@ -34,6 +36,8 @@ repositories {
 		url = "https://server.bbkr.space/artifactory/libs-release"
 	}
 	maven { url 'https://jitpack.io' }
+	maven { url 'https://maven.shedaniel.me' }
+	maven { url 'https://maven.terraformersmc.com' }
 
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ fabric_version=0.45.0+1.18
 # Dependencies
 libgui_version=5.2.0+1.18
 config_version=1.2.1-1.18.1
+mod_menu_version=3.0.1
 # Mod Properties
 mod_version = 0.6.3+1.18
 maven_group = io.github.frqnny

--- a/src/main/java/io/github/frqnny/darkenchanting/DarkEnchantingClient.java
+++ b/src/main/java/io/github/frqnny/darkenchanting/DarkEnchantingClient.java
@@ -1,5 +1,6 @@
 package io.github.frqnny.darkenchanting;
 
+import draylar.omegaconfiggui.OmegaConfigGui;
 import io.github.frqnny.darkenchanting.init.ModBlocks;
 import io.github.frqnny.darkenchanting.init.ModGUIs;
 import net.fabricmc.api.ClientModInitializer;
@@ -15,6 +16,8 @@ public class DarkEnchantingClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        OmegaConfigGui.registerConfigScreen(DarkEnchanting.CONFIG);
+
         ModGUIs.clientInit();
         ModBlocks.clientInit();
 

--- a/src/main/java/io/github/frqnny/darkenchanting/client/renderer/DarkEnchanterBlockEntityRenderer.java
+++ b/src/main/java/io/github/frqnny/darkenchanting/client/renderer/DarkEnchanterBlockEntityRenderer.java
@@ -11,9 +11,9 @@ import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.entity.model.BookModel;
 import net.minecraft.client.render.entity.model.EntityModelLayers;
-import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.util.SpriteIdentifier;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3f;
@@ -21,7 +21,7 @@ import net.minecraft.util.math.Vec3f;
 @Environment(EnvType.CLIENT)
 public class DarkEnchanterBlockEntityRenderer implements BlockEntityRenderer<DarkEnchanterBlockEntity> {
     public static final Identifier BOOK_ID = DarkEnchanting.id("entity/book1");
-    private static final SpriteIdentifier BOOK_TEX = new SpriteIdentifier(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE, BOOK_ID);
+    private static final SpriteIdentifier BOOK_TEX = new SpriteIdentifier(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE, BOOK_ID);
     private final BookModel book;
 
     public DarkEnchanterBlockEntityRenderer(BlockEntityRendererFactory.Context ctx) {

--- a/src/main/java/io/github/frqnny/darkenchanting/config/DarkEnchantingConfig.java
+++ b/src/main/java/io/github/frqnny/darkenchanting/config/DarkEnchantingConfig.java
@@ -4,13 +4,14 @@ import com.google.common.collect.Lists;
 import draylar.omegaconfig.api.Comment;
 import draylar.omegaconfig.api.Config;
 import draylar.omegaconfig.api.Syncing;
+import io.github.frqnny.darkenchanting.DarkEnchanting;
 
 import java.util.ArrayList;
 
 @Syncing
 public class DarkEnchantingConfig implements Config {
     @Comment("""
-            
+
             Performance: Decide whether Dark Conduits emit particles.
             True means they do emit particles.
             Default: true
@@ -19,7 +20,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Enchantments will cost this many levels for any transactions.
             Default: 3.0
             """)
@@ -27,7 +28,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Each enchantment's cost is multiplied by this value.
             Default: 1.0
             """)
@@ -35,7 +36,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Removing an enchantment from gear will give XP back.
             The amount received back is multiplied by this value.
             Default: 0.49
@@ -44,7 +45,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Each CURSE enchantment's cost is multiplied by this value.
             Curse Enchantments will show up as red on the Dark Enchanter.
             Default: 3.0
@@ -53,7 +54,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Each TREASURE enchantment's cost is multiplied by this value.
             TREASURE Enchantments will show up as blue on the Dark Enchanter.
             Default: 4.0
@@ -62,18 +63,18 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Enchantments contain a certain weight, viewable in the Minecraft Wiki.
             Weight Divisor is used to determine a specialWeightFactor.
             We perform the calculation:
-            
+
             (11 - weight) / weightDivisor = specialWeightFactor
-            
+
             specialWeightFactor will ALWAYS be greater than 1. Meaning, if the calculation provides a specialWeightFactor less than 1, we will just use 1 instead.
-            
+
             For example, Sharpness has a weight of 10, while Mending will have a weight of 2.
             In the equation, Sharpness will have a factor of 1 while Mending will have a factor of 4.5 (WITH DEFAULTS).
-            
+
             TLDR: higher values means that this will DECREASE rarer enchantment's cost, while lower values will INCREASE the cost.
             Default: 2.0
             """)
@@ -81,7 +82,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             Repairing any item will have its cost multiplied by this value.
             Default: 1.0
             """)
@@ -89,7 +90,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             This number represents the discount from bookshelves.
             Default: 0.4 (40%)
             """)
@@ -97,7 +98,7 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             This number represents the discount from Dark Conduits.
             Default: 0.1 (10%)
             """)
@@ -105,10 +106,10 @@ public class DarkEnchantingConfig implements Config {
 
     @Syncing
     @Comment("""
-            
+
             This list can be used to configure specific enchantments.
             The values are as follows:
-                
+
                 enchantmentId: The In-Game identification of the Enchantment.
                     No Default.
                 activated: Determines whether the enchantment will be available in the Dark Enchanter.
@@ -116,7 +117,7 @@ public class DarkEnchantingConfig implements Config {
                 personalFactor: During transactions, the cost of the specific enchantment is multiplied by this value.
                     Default: 1.0
                 personalReceiveFactor: Removing enchantments allows you to receive back some XP. The amount received is multiplied by this value.
-                    
+
             Below is an example entry for Sharpness with its defaults.
             """)
     public ArrayList<ConfigEnchantment> configEnchantments = Lists.newArrayList(ConfigEnchantment.of("minecraft:sharpness", 1.0F, true, 1.0F));
@@ -130,5 +131,10 @@ public class DarkEnchantingConfig implements Config {
     @Override
     public String getExtension() {
         return "json5";
+    }
+
+    @Override
+    public String getModid() {
+        return DarkEnchanting.MODID;
     }
 }

--- a/src/main/java/io/github/frqnny/darkenchanting/init/ModBlocks.java
+++ b/src/main/java/io/github/frqnny/darkenchanting/init/ModBlocks.java
@@ -11,8 +11,8 @@ import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.util.registry.Registry;
 
 public class ModBlocks {
@@ -30,14 +30,10 @@ public class ModBlocks {
 
     public static void clientInit() {
         BlockEntityRendererRegistry.register(ModBlocks.DE_BLOCK_ENTITY, DarkEnchanterBlockEntityRenderer::new);
-        ClientSpriteRegistryCallback.event(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE).register((atlas, registry) -> registry.register(DarkEnchanterBlockEntityRenderer.BOOK_ID));
+        ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlas, registry) -> registry.register(DarkEnchanterBlockEntityRenderer.BOOK_ID));
     }
 
 
 
 
 }
-
-
-
-

--- a/src/main/java/io/github/frqnny/darkenchanting/util/BookcaseUtils.java
+++ b/src/main/java/io/github/frqnny/darkenchanting/util/BookcaseUtils.java
@@ -16,26 +16,27 @@ public class BookcaseUtils {
 
     //Inner ring
     public static boolean getObsidianCount(World world, BlockPos blockPos) {
+        Tag<Block> obsidianTag = world.getTagManager().getTag(Registry.BLOCK_KEY, new Identifier(DarkEnchanting.MODID, "crying_obsidian"), id -> new RuntimeException("Could not load tag: " + id.toString()));
         int base_obsidian = 0;
         int z;
         for (z = -1; z <= 1; ++z) { // LOOP for Y level
             for (int x = -1; x <= 1; ++x) { // LOOP for Z level
                 if ((z != 0 || x != 0) && world.isAir(blockPos.add(x, 0, z)) && world.isAir(blockPos.add(x, 1, z))) //check if block not center
                 {
-                    /* 
+                    /*
                     check block on Coords:
                     relative to dark enchanter btw,
                     */
-                    if (world.getBlockState(blockPos.add(x * 2, -1, z * 2)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                    if (world.getBlockState(blockPos.add(x * 2, -1, z * 2)).isIn(obsidianTag)) {
                         ++base_obsidian;
                     }
 
                     if (x != 0 && z != 0) {
-                        if (world.getBlockState(blockPos.add(x * 2, -1, z)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                        if (world.getBlockState(blockPos.add(x * 2, -1, z)).isIn(obsidianTag)) {
                             ++base_obsidian;
                         }
 
-                        if (world.getBlockState(blockPos.add(x, -1, z * 2)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                        if (world.getBlockState(blockPos.add(x, -1, z * 2)).isIn(obsidianTag)) {
                             ++base_obsidian;
                         }
                     }
@@ -59,7 +60,7 @@ public class BookcaseUtils {
                         if ((z != 0 || x != 0) && world.isAir(blockPos.add(x, 0, z)) && world.isAir(blockPos.add(x, 1, z))) //check if block not center
                         {
                             // Y level is hardcoded, only check for y lvl 0,1
-                            /* 
+                            /*
                             check block on:
                             relative to dark enchanter btw,
                             everything that is labeled 1
@@ -72,7 +73,7 @@ public class BookcaseUtils {
                             if (world.getBlockState(blockPos.add(x * 2, y, z * 2)).isIn(bookshelvesTag)) {
                                 ++bookshelves;
                             }
-                            /* 
+                            /*
                             check block on:
                             relative to dark enchanter btw,
                             everything that is labeled 0
@@ -103,6 +104,7 @@ public class BookcaseUtils {
 
     //outer ring
     public static boolean getObsidianCount_2(World world, BlockPos blockPos) {
+        Tag<Block> obsidianTag = world.getTagManager().getTag(Registry.BLOCK_KEY, new Identifier(DarkEnchanting.MODID, "crying_obsidian"), id -> new RuntimeException("Could not load tag: " + id.toString()));
         int base_obsidian_2 = 0;
         int z;
         int x;
@@ -127,12 +129,12 @@ public class BookcaseUtils {
                 -4 0 2,
                 -4 0 3
                 */
-                if (world.getBlockState(blockPos.add(4, y, z)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                if (world.getBlockState(blockPos.add(4, y, z)).isIn(obsidianTag)) {
                     //System.out.println("obsidian found at :" + 4 +","+y+","+z);
                     ++base_obsidian_2;
                 }
                 if (z != 4) {
-                    if (world.getBlockState(blockPos.add(-4, y, z)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                    if (world.getBlockState(blockPos.add(-4, y, z)).isIn(obsidianTag)) {
                         //System.out.println("obsidian found at :" + -4 +","+y+","+ z);
                         ++base_obsidian_2;
                     }
@@ -155,12 +157,12 @@ public class BookcaseUtils {
                 -3 0 -4                                                  -3 0 4
                 -4 0 -4,                                                 -4 0 4
                 */
-                if (world.getBlockState(blockPos.add(x, y, 4)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                if (world.getBlockState(blockPos.add(x, y, 4)).isIn(obsidianTag)) {
                     //System.out.println("obsidian found at :" + x +","+y+","+4);
                     ++base_obsidian_2;
                 }
                 if (x != 4) {
-                    if (world.getBlockState(blockPos.add(x, y, -4)).isOf(Blocks.CRYING_OBSIDIAN)) {
+                    if (world.getBlockState(blockPos.add(x, y, -4)).isIn(obsidianTag)) {
                         //System.out.println("obsidian found at :" + x +","+y+","+-4);
                         ++base_obsidian_2;
                     }
@@ -185,20 +187,20 @@ public class BookcaseUtils {
                     if (z != 0) { //check if block not center
                         /*
                         check Corners
-                        
-                         4 0 -3, 
-                         4 0 -2, 
+
+                         4 0 -3,
+                         4 0 -2,
                          4 0 - 1
-                         4 0 0, 
-                         4 0 1, 
-                         4 0 2, 
+                         4 0 0,
+                         4 0 1,
+                         4 0 2,
                          4 0 3
                         -4 0 -3,
                         -4 0 -2,
                         -4 0 0,
                         -4 0 1,
                         -4 0 2,
-                        -4 0 3                       
+                        -4 0 3
                         */
                         if (world.getBlockState(blockPos.add(4, y, z)).isIn(bookshelvesTag)) {
                             //System.out.println("obsidian found at :" + 4 +","+y+","+z);
@@ -217,7 +219,7 @@ public class BookcaseUtils {
 
                         /*
                         check Corners
-                        
+
                         -4 0 -4                                                   4 0 4
                         3 0 -4                                                    3 0 4
                         2 0 -4                                                    2 0 4
@@ -226,7 +228,7 @@ public class BookcaseUtils {
                         -1 0 -4                                                  -1 0 4
                         -2 0 -4                                                  -2 0 4
                         -3 0 -4                                                  -3 0 4
-                        -4 0 -4,                                                 -4 0 4                         
+                        -4 0 -4,                                                 -4 0 4
                         */
                         if (world.getBlockState(blockPos.add(x, y, 4)).isIn(bookshelvesTag)) {
                             //System.out.println("obsidian found at :" + x +","+y+","+4);

--- a/src/main/resources/data/dark-enchanting/tags/blocks/crying_obsidian.json
+++ b/src/main/resources/data/dark-enchanting/tags/blocks/crying_obsidian.json
@@ -1,0 +1,10 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:crying_obsidian",
+        {
+            "id": "betternether:blue_crying_obsidian",
+            "required": false
+        }
+    ]
+}


### PR DESCRIPTION
Created a `crying_obsidian` tag that includes vanilla crying obsidian and blue crying obsidian from the BetterNether mod. This will also allow any other mods that add crying obsidian to easily add compat with this mod via datapacks.

Also enabled the ModMenu gui since that seems to work in 1.18 now

It may be preferable not to add the BetterNether value here, but instead in the BetterNether mod, but that would still require creating and using the tag here first. It was just simple to do so I put it in.